### PR TITLE
Add contribution guidelines and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Report something that isn't working correctly
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please search
+        [existing issues](../issues) first to avoid duplicates.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+      placeholder: When I do X, Y happens instead of Z.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Run `make start`
+        2. Go to '...'
+        3. Click on '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Run mode
+      description: How are you running the project?
+      options:
+        - Local development (native, SQLite)
+        - Production stack (Docker Compose, Postgres + Redis)
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, Node version, browser (if relevant).
+      placeholder: |
+        - OS: macOS 15
+        - Python: 3.14 (via uv)
+        - Node: 24.x
+        - Browser: Chrome 138
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or tracebacks
+      description: Paste any relevant output. This will be formatted as code automatically.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/achingachris/django-starter/discussions
+    about: Ask questions or discuss ideas that aren't a concrete bug or feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest an idea or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! For large changes, please open an issue to
+        discuss the approach before starting on a pull request.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the problem or limitation, not just the solution you have in mind.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, links, or anything else that helps explain the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!-- Thanks for contributing! Please fill out the sections below. -->
+
+## Description
+
+<!-- What does this PR change, and why? -->
+
+## Related issues
+
+<!-- Link related issues, e.g. "Fixes #123" or "Relates to #456". -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would change existing behavior)
+- [ ] Refactor / code quality (no functional change)
+- [ ] Documentation
+- [ ] CI / tooling
+
+## How has this been tested?
+
+<!-- Describe the tests you ran or added. Include commands and relevant output. -->
+
+## Checklist
+
+- [ ] My branch is up to date with `main`
+- [ ] `pre-commit run --all-files` passes (code style)
+- [ ] `mypy .` passes (type checking)
+- [ ] `make test` passes (Django tests)
+- [ ] `make npm-build` and `make npm-type-check` pass (if front-end code changed)
+- [ ] I added tests covering my changes (if applicable)
+- [ ] I updated documentation (README, etc.) where needed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,5 +135,3 @@ New features and bug fixes should include tests covering the change.
   `{% vite_asset %}`.
 - Use Django signals sparingly and document them well.
 - Always validate user input server-side.
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# Contributing
+
+Thanks for your interest in contributing to this project! This document explains how to set up
+your environment, the standards we follow, and how to submit issues and pull requests.
+
+## Table of contents
+
+- [Getting started](#getting-started)
+- [Reporting issues](#reporting-issues)
+- [Suggesting features](#suggesting-features)
+- [Submitting pull requests](#submitting-pull-requests)
+- [Code style](#code-style)
+- [Running tests](#running-tests)
+- [Project conventions](#project-conventions)
+
+## Getting started
+
+Local development runs **natively** (no Docker) using [uv](https://docs.astral.sh/uv/) and `npm`
+against SQLite. See the [README](README.md) for full details.
+
+### Prerequisites
+
+- **Python 3.14** with a virtual environment tool of your choice.
+  [uv](https://docs.astral.sh/uv/getting-started/installation/) is recommended (the `Makefile`
+  targets use it, and it provisions Python 3.14 for you), but it is not a must — `venv` + `pip`,
+  virtualenv, Poetry, etc. all work. Dependencies are declared in `pyproject.toml`.
+- [Node.js](https://nodejs.org/) 20+ — provides `node` and `npm`
+- `make` — preinstalled on macOS/Linux
+
+### Setup
+
+With uv (recommended — matches the `Makefile` and CI):
+
+```bash
+make init      # copy .env, install Python + npm dependencies, create and migrate the SQLite DB
+```
+
+With another environment tool, the equivalent steps are:
+
+```bash
+cp .env.example .env
+python3.14 -m venv .venv && source .venv/bin/activate   # or your preferred tool
+pip install -e .            # runtime dependencies (from pyproject.toml)
+pip install --group dev     # dev tools: pre-commit, ruff, mypy, etc. (needs pip 25.1+)
+npm install
+python manage.py migrate
+```
+
+The rest of this guide shows `make` / `uv run` commands; if you're not using uv, run the
+underlying command directly inside your activated environment (e.g. `python manage.py test`
+instead of `make test`).
+
+Then run the app with **two processes in two terminals**:
+
+```bash
+make start     # Terminal 1: Django dev server (http://localhost:8000)
+make npm-dev   # Terminal 2: Vite front-end dev server (hot-reloaded CSS/JS)
+```
+
+Run `make` with no arguments to list all available commands.
+
+## Reporting issues
+
+Before opening an issue, please search
+[existing issues](../../issues) to avoid duplicates.
+
+When filing a bug report, use the **Bug report** issue template and include:
+
+- Clear steps to reproduce the problem
+- What you expected to happen vs. what actually happened
+- Your environment (OS, Python/Node versions, local vs. Docker production mode)
+- Relevant logs, tracebacks, or screenshots
+
+## Suggesting features
+
+Use the **Feature request** issue template. Describe the problem you're trying to solve, not just
+the solution — this helps us evaluate alternatives. For large changes, please open an issue to
+discuss the approach *before* investing time in a pull request.
+
+## Submitting pull requests
+
+1. **Fork** the repository and create a branch from `main`:
+   ```bash
+   git checkout -b my-feature main
+   ```
+2. Make your changes, keeping each pull request **focused on a single concern**.
+3. Ensure the full local check suite passes (see below).
+4. Write a clear PR description using the pull request template — explain **what** changed and
+   **why**, and link any related issues (e.g. `Fixes #123`).
+5. Be responsive to review feedback; maintainers may request changes before merging.
+
+Every pull request must pass CI, which runs:
+
+| Check | Command to reproduce locally |
+|-------|------------------------------|
+| Code style (pre-commit: ruff + hygiene hooks) | `pre-commit run --all-files` |
+| Type checking (mypy) | `mypy .` |
+| Django tests (against Postgres + Redis in CI) | `make test` (or `python manage.py test`) |
+| Front-end build + TypeScript check | `make npm-build && make npm-type-check` |
+
+(Run these inside your activated environment; with uv, prefix Python commands with `uv run`.)
+
+## Code style
+
+- **Python**: PEP 8 with a 120-character line limit, double quotes, isort-sorted imports — all
+  enforced by [ruff](https://docs.astral.sh/ruff/). Run `make ruff` to format and lint.
+- **JavaScript/TypeScript**: ES6+, 2-space indentation, single quotes, semicolons.
+- **Django templates**: 2-space indentation, DaisyUI/Tailwind classes for styling.
+- Prefer simple solutions and avoid duplicating existing functionality.
+- Use type hints in new Python code where practical.
+
+We recommend installing the git hooks so style issues are caught before you push:
+
+```bash
+pre-commit install   # prefix with `uv run` if using uv
+```
+
+## Running tests
+
+```bash
+make test                                       # run all tests
+make test ARGS='apps.module.tests.test_file'    # run a specific test module
+make test ARGS='path.to.test --keepdb'          # pass extra options
+```
+
+New features and bug fixes should include tests covering the change.
+
+## Project conventions
+
+- Django models extend `apps.utils.models.BaseModel` (adds `created_at` / `updated_at`).
+- The user model is `apps.users.models.CustomUser` — import it directly.
+- Prefer function-based views, except where a framework expects class-based views (e.g. DRF).
+- HTMX for server-backed interactivity, Alpine.js for browser-only interactivity.
+- Front-end assets live in `/assets/` and are built by Vite; load them in templates with
+  `{% vite_asset %}`.
+- Use Django signals sparingly and document them well.
+- Always validate user input server-side.
+
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2026 Chris Achinga
+Copyright (c) 2026 Elodin Labs LLC (SaaS Pegasus)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Elodin Labs LLC (SaaS Pegasus)
+Copyright (c) 2026 Chris Achinga
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Description

Sets up the repository's community health files per [GitHub's contributor guidelines docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors):

- **CONTRIBUTING.md** — environment setup (uv recommended but any Python venv tool works, with a pip-based alternative), how to report issues and propose features, the PR process with a table of CI checks and the local commands to reproduce them, code style rules, and project conventions.
- **.github/PULL_REQUEST_TEMPLATE.md** — description, linked issues, type-of-change checkboxes, and a pre-flight checklist mirroring CI.
- **.github/ISSUE_TEMPLATE/** — YAML issue forms for bug reports (with a local-vs-Docker run-mode dropdown) and feature requests, plus `config.yml` disabling blank issues and routing questions to Discussions.

Also updates the LICENSE copyright holder to Chris Achinga.

## How has this been tested?

All new files pass the repo's pre-commit hooks (`pre-commit run --files ...`). Template rendering can be verified on GitHub once merged (issue forms and PR template only take effect from the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)